### PR TITLE
refactor: automerge minor and patch versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,7 +24,7 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
-  "prCreation": "status-success",
+  "prCreation": "immediate",
   "onboardingPrTitle": "chore(deps): onboard with renovate",
   "gomod": {
     "enabled": true,
@@ -37,7 +37,6 @@
   "vulnerabilityAlerts": {
     "enabled": true,
     "prCreation": "immediate",
-
     "labels": [
       "security"
     ]
@@ -55,7 +54,13 @@
     "enabled": true
   },
   "major": {
-    "dependencyDashboardApproval": true
+    "dependencyDashboardApproval": true,
+  },
+  "minor": {
+     "automerge": true
+  },
+  "patch": {
+     "automerge": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
- If there are no tests in place, renovate won't do this per docs.
- This won't automerge when codeowners are applied anyway.
- This will ensure only an approval is required and then the PR will be set to autocomplete.