### PR TITLE
refactor(renovate): enable pinning github actions and improve grouping for mage

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,10 @@
     "schedule:earlyMondays",
     ":semanticCommitTypeAll(chore)",
     "github>whitesource/merge-confidence:beta",
-    "github>aquaproj/aqua-renovate-config#1.2.6"
+    "github>aquaproj/aqua-renovate-config#1.2.6",
+    "helpers:pinGitHubActionDigests",
+    "regexManagers:githubActionsVersions",
+    "regexManagers:dockerfileVersions"
   ],
   "labels": ["dependencies"],
   "binarySource": "docker",
@@ -68,7 +71,12 @@
       "prPriority": -1
     },
     {
-      "matchPackagePatterns": ["github.com/sheldonhull/magetools"],
+      "matchPackagePatterns": [
+        "github.com/magefile/mage",
+        "github.com/sheldonhull/magetools",
+        "github.com/bitfield/script",
+        "github.com/pterm/pterm"
+      ],
       "groupName": "mage-tooling",
       "commitMessageTopic": "🤖 mage tooling",
       "automerge": true,


### PR DESCRIPTION
- Use preset for pinning github actions.
- Group packages used in magefiles.
- Add more version regex helpers.