### PR TITLE
refactor: group github actions into single PR

### DIFF
--- a/default.json
+++ b/default.json
@@ -88,9 +88,10 @@
     },
     {
       "matchPaths": [".github"],
+      "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "automerge": true,
-      "commitMessageTopic": "🤖 github actions {{depName}}",
+      "commitMessageTopic": "🤖 github actions",
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "prPriority": -1,
       "prBodyDefinitions": {

--- a/default.json
+++ b/default.json
@@ -8,7 +8,9 @@
     "github>aquaproj/aqua-renovate-config#1.2.6",
     "helpers:pinGitHubActionDigests",
     "regexManagers:githubActionsVersions",
-    "regexManagers:dockerfileVersions"
+    "regexManagers:dockerfileVersions",
+    ":enableVulnerabilityAlerts",
+    "group:linters"
   ],
   "labels": ["dependencies"],
   "binarySource": "docker",
@@ -23,6 +25,7 @@
   "rangeStrategy": "pin",
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "prCreation": "not-pending",
+  "prConcurrentLimit": 3,
   "onboardingPrTitle": "chore(deps): onboard with renovate",
   "gomod": {
     "enabled": true,


### PR DESCRIPTION
- Add more preset helpers.
- Ensure github actions are grouped into single PR to reduce noise.
