### PR TITLE
chore(renovate): remove deprecated matchPaths and replace with `matchFileNames`

### DIFF
--- a/default.json
+++ b/default.json
@@ -66,7 +66,7 @@
       "commitMessageTopic": "☁️ aws-sdk update {{depName}}"
     },
     {
-      "matchPaths": ["magefiles"],
+      "matchFileNames": ["**/magefiles/**", "magefile.go", "mage.go"],
       "groupName": "mage-tooling",
       "commitMessageTopic": "🤖 mage tooling",
       "automerge": true,
@@ -87,7 +87,7 @@
       "prPriority": -1
     },
     {
-      "matchPaths": [".github"],
+      "matchFileNames": ["**/.github/**"],
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "automerge": true,
@@ -118,7 +118,7 @@
       "enabled": false
     },
     {
-      "matchPaths": ["aqua.yaml", "registry.yaml"],
+      "matchFileNames": ["aqua.yaml", "registry.yaml"],
       "groupName": "aqua-packages",
       "automerge": true,
       "commitMessageTopic": "🤖 aqua tooling",


### PR DESCRIPTION
See [version 36](https://docs.renovatebot.com/release-notes-for-major-versions/#version-36) breaking change notes: 

> matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed